### PR TITLE
allow DaskSpectralCube, etc. to work w/gui

### DIFF
--- a/pvextractor/gui.py
+++ b/pvextractor/gui.py
@@ -250,8 +250,8 @@ class PVSlicer(object):
     def __init__(self, filename_or_cube, backend=None, clim=None, cmap=None):
 
         try:
-            from spectral_cube import SpectralCube
-            if isinstance(filename_or_cube, SpectralCube):
+            from spectral_cube import SpectralCube, BaseSpectralCube
+            if hasattr(filename_or_cube, 'filled_data') or issubclass(filename_or_cube, BaseSpectralCube):
                 cube = filename_or_cube
             else:
                 cube = SpectralCube.read(filename_or_cube, format='fits')


### PR DESCRIPTION
"isinstance" started failing w/DaskSpectralCube classes, so we check for duck-like attributes or subclass.

I picked a random attribute because I wasn't sure which one(s) we use; please suggest fixes if you figure out a better match!